### PR TITLE
Changed Script for Chatbotish in index.js

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,14 +31,13 @@ const Home: React.FC = () => {
     <>
       <Head>
         <link href="https://chatbotish.vercel.app/index.css" rel="stylesheet" />
-        <Script
+      </Head>
+      <Script
           src="https://chatbotish.vercel.app/index.js"
           data-chatbotish
           data-id="HD78EFfUJSI7sFbTdfnO"
           strategy="lazyOnload"
         ></Script>
-      </Head>
-
       {isLoading ? (
         <div className="w-screen h-screen flex justify-center items-center">
           <motion.div initial={{ x: -500 }} animate={{ x: 0 }}>


### PR DESCRIPTION
According to NextJS documentation the `next/script` must not be placed in either a `next/head` component or `pages/_document.tsx`. So in this PR I moved the Script tag from Head tag

![image](https://user-images.githubusercontent.com/54738622/131482677-01670ad6-4547-4cfa-82f2-62a86fecff27.png)
